### PR TITLE
Add wet/dry dep, settling, hourly averaged HWP, wind gust, and hooks for heat flux

### DIFF
--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2980,6 +2980,46 @@
   type = real
   kind = kind_phys
   active = (do_smoke_coupling)
+[rrfs_hwp_ave]
+  standard_name = hourly_wildfire_potential_average
+  long_name = rrfs hourly fire weather potential average
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+[fire_heat_flux_out]
+  standard_name = surface_fire_heat_flux
+  long_name = heat flux of fire at the surface
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+[wetdpr_smoke]
+  standard_name = wet_deposition_flux_thompson_mp_smoke
+  long_name = wet deposition flux of smoke in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+[wetdpr_dust]
+  standard_name = wet_deposition_flux_thompson_mp_dust_1
+  long_name = wet deposition flux of fine dust in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+[wetdpr_coarsepm]
+  standard_name = wet_deposition_flux_thompson_mp_coarse_pm
+  long_name = wet deposition flux of coarse dust in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
 [drydep_flux_smoke]
   standard_name = dry_deposition_flux_smoke
   long_name = rrfs dry deposition flux of smoke

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -4618,14 +4618,73 @@ module GFS_diagnostics
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
-      ExtDiag(idx)%name = 'HWP'
-      ExtDiag(idx)%desc = 'hourly fire weather potential'
+      ExtDiag(idx)%name = 'HWPI'
+      ExtDiag(idx)%desc = 'instantaneous hourly fire weather potential'
       ExtDiag(idx)%unit = ' '
+      ExtDiag(idx)%time_avg = .FALSE.
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
         ExtDiag(idx)%data(nb)%var2 => Coupling(nb)%rrfs_hwp
       enddo
+
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'HWP'
+      ExtDiag(idx)%desc = 'average hourly fire weather potential'
+      ExtDiag(idx)%unit = ' '
+      ExtDiag(idx)%time_avg = .TRUE.
+      ExtDiag(idx)%mod_name = 'gfs_sfc'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => Coupling(nb)%rrfs_hwp_ave
+      enddo
+
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'fire_heat_flux_out'
+      ExtDiag(idx)%desc = 'hourly fire heat flux'
+      ExtDiag(idx)%unit = 'W m-2'
+      ExtDiag(idx)%mod_name = 'gfs_sfc'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => Coupling(nb)%fire_heat_flux_out
+      enddo
+
+!      if (Model%wraerosol) then
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'wetdpr_smoke'
+      ExtDiag(idx)%desc = 'wet deposition flux of smoke'
+      ExtDiag(idx)%unit = 'ug m-2'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => Coupling(nb)%wetdpr_smoke
+      enddo
+
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'wetdpr_dust'
+      ExtDiag(idx)%desc = 'wet deposition flux of fine dust'
+      ExtDiag(idx)%unit = 'ug m-2'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => Coupling(nb)%wetdpr_dust
+      enddo
+
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'wetdpr_coarsepm'
+      ExtDiag(idx)%desc = 'wet deposition flux of coarse dust'
+      ExtDiag(idx)%unit = 'ug m-2'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => Coupling(nb)%wetdpr_coarsepm
+      enddo
+ !     endif ! wet removal of aerosol in thmp MP is active
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2


### PR DESCRIPTION
## Description

New dry deposition option following Emerson et al. (2020) with gravitational settling
Gravitational settling now controlled by namelist pm_settling (was coarsepm_settling)
Calculation of HOURLY-AVERAGE HWP
Pass out fire_heat_flux to be used by Tanya's updates
Calculation of wind gust potential using PBLH from MYNN (following UPP)
Wet deposition from resolved precipitation in Thompson MP controlled by logical namelist: wraerosol
Resolved wet deposition diagnostics


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
