### PR TITLE
allocate rho_dry to zero size when not in use

### DIFF
--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -3536,6 +3536,7 @@ module GFS_typedefs
       allocate (Coupling%min_fplume(0))
       allocate (Coupling%max_fplume(0))
       allocate (Coupling%uspdavg(0))
+      allocate (Coupling%rho_dry   (0,0))
       allocate (Coupling%hpbl_thetav(0))
       allocate (Coupling%rrfs_hwp  (0))
       allocate (Coupling%rrfs_hwp_ave  (0))


### PR DESCRIPTION
This should fix the error reported in https://github.com/ufs-community/ufs-weather-model/pull/2170. 

For the `check all` fix in the RRFS release branch, all arrays that were previously conditionally-allocated in GFS_typedefs and CCPP_typedefs need to be allocated always. Arrays that are not in use for a given condition still need to be allocated to zero size. This is a temporary fix for the RRFS release branch.
